### PR TITLE
Pin script to old version. makes things work again

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# Version 0.2.3
+- Pin script version to pre paho v2
+- Make sure debug.log exists before tailing it
+
 # Version 0.2.2
 - Changes to run.sh to run the deamon and tail the debug log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-ARG BUILD_FROM                                                                                                                                
-FROM $BUILD_FROM                                                                                                                              
-                                                                                                                                              
-ENV LANG C.UTF-8                                                                                                                              
-WORKDIR /data                                                                                                                                 
-RUN apk add --no-cache --virtual .build-dependencies udev git python3 py3-yaml py3-paho-mqtt py3-pyserial && \                                
-    mkdir -p /opt/kamstrup && \
-    git clone https://github.com/matthijsvisser/kamstrup-402-mqtt.git /opt/kamstrup &&  \                                                     
-    mkdir -p /opt/kamstrup/logs && \
-    touch /opt/kamstrup/logs/debug.log && \
-    apk del git --quiet                                                                                                                       
-                                                                                                                                              
-# Copy data for add-on                                                                                                                        
-COPY run.sh /                                                                                                                                 
-RUN chmod a+x /run.sh                                                                                                                         
-                                                                                                                                              
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+ENV LANG C.UTF-8
+WORKDIR /data
+RUN apk add --no-cache --virtual .build-dependencies udev git python3 py3-yaml py3-paho-mqtt py3-pyserial && \ 
+    mkdir -p /opt/kamstrup && \ 
+    git clone https://github.com/matthijsvisser/kamstrup-402-mqtt.git /opt/kamstrup && \
+    cd /opt/kamstrup && \
+    git checkout 00083f717ae5b90ab216e1cb977269978251f369 && \
+    apk del git --quiet 
+
+# Copy data for add-on
+COPY run.sh /
+RUN chmod a+x /run.sh
+
 CMD [ "/run.sh" ]

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.2
+version: 0.2.3
 slug: kamstrup
 name: Kamstrup 402 & 403 Logger
 description: Kamstrup Warmtemeter data logger

--- a/run.sh
+++ b/run.sh
@@ -12,4 +12,7 @@ sed -i "s/poll_interval: .*/poll_interval: $(bashio::config 'poll_interval')/g" 
 
 echo "Starting Daemon..."
 /usr/bin/python3 /opt/kamstrup/daemon.py &
+mkdir -p /opt/kamstrup/logs
+touch /opt/kamstrup/logs/debug.log
+echo "Tailing log"
 tail -f /opt/kamstrup/logs/debug.log


### PR DESCRIPTION
The latest version of the upstream script expects paho v2 while Alpine is on v1.6. This pins the version of the script to a known working one.